### PR TITLE
chore: update nstuning-app to v1.0.0

### DIFF
--- a/charts/nstuning-app/Chart.yaml
+++ b/charts/nstuning-app/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.0
+version: 0.1.1

--- a/charts/nstuning-app/values.yaml
+++ b/charts/nstuning-app/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: sondresjo/nstuning-app
   pullPolicy: IfNotPresent
-  tag: "v0.1.0"
+  tag: "v1.0.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Updates `nstuning-app` image tag to `v1.0.0` and bumps chart version to `0.1.1`.