### PR TITLE
chore: update nstuning-api to v1.1.0

### DIFF
--- a/charts/nstuning-api/Chart.yaml
+++ b/charts/nstuning-api/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.1
+version: 0.1.2

--- a/charts/nstuning-api/values.yaml
+++ b/charts/nstuning-api/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: sondresjo/nstuning-api
   pullPolicy: IfNotPresent
-  tag: "v1.0.0"
+  tag: "v1.1.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Updates `nstuning-api` image tag to `v1.1.0` and bumps chart version to `0.1.2`.