### PR TITLE
fix(nstuning-api): mount image storage path

### DIFF
--- a/charts/nstuning-api/Chart.yaml
+++ b/charts/nstuning-api/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.2
+version: 0.1.3

--- a/charts/nstuning-api/templates/deployment.yaml
+++ b/charts/nstuning-api/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
             {{- if .Values.persistence.enabled }}
             - name: Storage__ReportsPath
               value: {{ .Values.persistence.mountPath | quote }}
+            - name: Storage__ImagesPath
+              value: {{ .Values.persistence.imagesPath | quote }}
             {{- end }}
             {{- range .Values.env }}
             - name: {{ .name }}
@@ -52,6 +54,9 @@ spec:
           volumeMounts:
             - name: reports
               mountPath: {{ .Values.persistence.mountPath }}
+            - name: reports
+              mountPath: {{ .Values.persistence.imagesPath }}
+              subPath: {{ .Values.persistence.imagesSubPath }}
           {{- end }}
       {{- if .Values.persistence.enabled }}
       volumes:

--- a/charts/nstuning-api/values.yaml
+++ b/charts/nstuning-api/values.yaml
@@ -38,6 +38,8 @@ persistence:
   accessMode: ReadWriteMany
   size: 20Gi
   mountPath: /data/reports
+  imagesPath: /data/images
+  imagesSubPath: images
 
 resources: {}
 


### PR DESCRIPTION
## Problem
Creating a dyno run with a cover image 500s in prod:

```
System.UnauthorizedAccessException: Access to the path '/data/images' is denied.
  at System.IO.Directory.CreateDirectory(...)
  at nstuning_api.Services.FileStorageBase..ctor(...)
```

The chart mounts the reports PVC at `/data/reports` and sets `Storage__ReportsPath`, but nothing backs the image path. `ImageStorageService` falls back to its default `/data/images`, which is on the container's (non-writable) root filesystem, so `Directory.CreateDirectory("/data/images")` fails. Reports work; images never had a mount.

## Fix
Back images with the same `reports` PVC via a `subPath`, and point the app at it:

- `values.yaml`: add `persistence.imagesPath` (`/data/images`) and `persistence.imagesSubPath` (`images`).
- `deployment.yaml`: add `Storage__ImagesPath` env and a second `volumeMount` of the `reports` volume at `imagesPath` with `subPath: images`.

PDFs stay at the PVC root (`/data/reports`); images land in an `images/` subdir on the same volume. No data migration.

Chart bumped `0.1.2` → `0.1.3` so chart-releaser publishes it.

## Deploy
After merge + chart publish, bump `NSTUNING_API_VERSION` to `0.1.3` in tumo-flux `clusters/production/postBuild.yaml` so Flux rolls it out.
