### PR TITLE
chore(nstuning-api): bump chart to 0.1.4

### DIFF
--- a/charts/nstuning-api/Chart.yaml
+++ b/charts/nstuning-api/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.3
+version: 0.1.4


### PR DESCRIPTION
Republish the image-storage mount fix.

Release `nstuning-api-0.1.3` was already cut by the v1.2.0 image bump before #9 merged, so chart-releaser refused to republish `0.1.3` and the `/data/images` mount fix never shipped. Bump to `0.1.4` so it publishes.

No other changes — the image mount config is already on main from #9.
