### PR TITLE
chore: update nstuning-app to v1.5.1

### DIFF
--- a/charts/nstuning-app/Chart.yaml
+++ b/charts/nstuning-app/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.6
+version: 0.1.7

--- a/charts/nstuning-app/values.yaml
+++ b/charts/nstuning-app/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: sondresjo/nstuning-app
   pullPolicy: IfNotPresent
-  tag: "v1.5.0"
+  tag: "v1.5.1"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Updates `nstuning-app` image tag to `v1.5.1` and bumps chart version to `0.1.7`.